### PR TITLE
v0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.3.0] (2019-03-24)
+
+- Dual license under Apache 2.0 / MIT ([#7])
+- Use 'accelerometer' crate types/traits ([#6])
+
 ## [0.2.0] (2019-03-21)
 
 - Provide access to raw accelerometer data ([#4])
@@ -6,6 +11,9 @@
 
 - Initial release
 
+[0.3.0]: https://github.com/NeoBirth/ADXL343.rs/pull/8
+[#7]: https://github.com/NeoBirth/ADXL343.rs/pull/7
+[#6]: https://github.com/NeoBirth/ADXL343.rs/pull/6
 [0.2.0]: https://github.com/NeoBirth/ADXL343.rs/pull/5
 [#4]: https://github.com/NeoBirth/ADXL343.rs/pull/4
 [0.1.0]: https://github.com/NeoBirth/ADXL343.rs/pull/3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "adxl343"
 description = "Platform-agnostic ADXL343 accelerometer driver which uses I2C via embedded-hal"
-version     = "0.2.0"
+version     = "0.3.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://neobirth.org"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 [![LGPL 3.0 licensed][license-image]][license-link]
 [![Gitter Chat][gitter-image]][gitter-link]
 
-ADXL343 accelerometer driver which uses I2C via `embedded-hal`. Usable via any
-compatible board crate (e.g. [trellis_m4])
+Platform-agnostic driver for the [Analog Devices ADXL343][device-info]
+3-axis accelerometer driver which uses I2C via `embedded-hal`.
+Usable via any compatible board crate (e.g. [trellis_m4]).
+
+Implements the [`Accelerometer` trait][acc-trait] from the
+[`accelerometer` crate][acc-crate].
 
 [Documentation][docs-link]
 
@@ -36,6 +40,9 @@ Dual licensed under your choice of either of:
 [license-link]: https://github.com/NeoBirth/ADXL343.rs/blob/master/LICENSE
 [gitter-image]: https://badges.gitter.im/NeoBirth/ADXL343.rs.svg
 [gitter-link]: https://gitter.im/NeoBirth/community
+[device-info]: https://www.analog.com/en/products/adxl343.html
 [trellis_m4]: https://crates.io/crates/trellis_m4
+[acc-trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.Accelerometer.html
+[acc-crate]: https://crates.io/crates/accelerometer
 [cc]: https://contributor-covenant.org
 [CODE_OF_CONDUCT.md]: https://github.com/NeoBirth/ADXL343.rs/blob/master/CODE_OF_CONDUCT.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
-//! ADXL343 accelerometer driver which uses I2C via [embedded-hal]
+//! Platform-agnostic ADXL343 accelerometer driver which uses I2C via
+//! [embedded-hal] and implements the [`Accelerometer` trait][trait]
+//! from the `accelerometer` crate.
 //!
 //! [embedded-hal]: https://docs.rs/embedded-hal
+//! [trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.Accelerometer.html
 
 #![no_std]
 #![deny(
@@ -13,7 +16,7 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/adxl343/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/adxl343/0.3.0")]
 
 extern crate embedded_hal as hal;
 


### PR DESCRIPTION
- Dual license under Apache 2.0 / MIT (#7)
- Use `accelerometer` crate types/traits (#6)