### PR TITLE
Accelerometer v0.4 upgrade + orientation tracker support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories  = ["embedded", "no-std"]
 keywords    = ["analog-devices", "accelerometer"]
 
 [dependencies]
-accelerometer = "0.3"
+accelerometer = { version = "0.4", features = ["orientation"] }
 bitflags = "1"
 embedded-hal = "0.2"
 


### PR DESCRIPTION
Adds support for converting the accelerometer type into a device orientation tracker.

See https://github.com/NeoBirth/accelerometer.rs/pull/15

Action shot (on the [NeoTrellis M4 Express](https://github.com/rust-embedded/wg/issues/286)):

![ezgif-1-16e98d9b86ad](https://user-images.githubusercontent.com/797/55564522-ebaf2b00-56ac-11e9-808f-9809e85c1bd2.gif)