### PR TITLE
Swap the endianness of accelerometer values read from device

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ where
     fn write_read_i16(&mut self, register: Register) -> Result<i16, E> {
         let mut buffer = [0u8; 2];
         self.write_read_register(register, &mut buffer)?;
-        Ok(i16::from_be_bytes(buffer))
+        Ok(i16::from_le_bytes(buffer))
     }
 
     /// Write to a given register, then read a `u16` result


### PR DESCRIPTION
Hi,

when testing on an ADXL345 accelerometer, that shares a device-id with the ADXL343 and looks to be mostly register-compatible, the measurements returned by accel_norm() and accel_raw() do not look quite right.

The datasheet for both ADXL345 and ADXL343 states, that:

> The output data is twos complement, with DATAx0 as the least significant byte and DATAx1 as the most significant byte

When treated as little endian i16 instead of as a big endian i16 the resulting accelerometer readings look more sensible.

Please note that I do not own an actual ADXL343 to test this patch on and that my assumtion that this patch should also work for that accelerometer is only based on the very similar datasheets.