### PR TITLE
Add support for SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Implements the [`Accelerometer` trait][acc-trait] from the
 ## Requirements
 
 - Rust 1.32+
-- `embedded-hal` I²C driver
+- `embedded-hal` I²C driver or SPI driver
 
 ## Code of Conduct
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 mod register;
+mod transport;
 
 pub use crate::register::{DataFormatFlags, DataFormatRange};
 pub use accelerometer;
-use embedded_hal as hal;
 
 use crate::register::Register;
 #[cfg(feature = "u16x3")]
@@ -26,7 +26,8 @@ use accelerometer::{
 };
 use accelerometer::{Error, ErrorKind, RawAccelerometer};
 use core::fmt::Debug;
-use hal::blocking::i2c::{Write, WriteRead};
+use transport::Transport;
+pub use transport::{I2cTransport, SpiTransport, TransportError};
 
 /// ADXL343 I2C address.
 /// Assumes ALT address pin low
@@ -36,33 +37,37 @@ pub const ADDRESS: u8 = 0x53;
 pub const DEVICE_ID: u8 = 0xE5;
 
 /// ADXL343 driver
-pub struct Adxl343<I2C> {
-    /// Underlying I2C device
-    i2c: I2C,
+pub struct Adxl343<T> {
+    /// Underlying device transport
+    transport: T,
 
     /// Current data format
     data_format: DataFormatFlags,
 }
 
-impl<I2C, E> Adxl343<I2C>
+impl<T, EBUS, EPIN> Adxl343<T>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-    E: Debug,
+    T: Transport<BusError = EBUS, PinError = EPIN>,
+    EBUS: Debug,
+    EPIN: Debug,
 {
-    /// Create a new ADXL343 driver from the given I2C peripheral
+    /// Create a new ADXL343 driver from the given peripheral
     ///
     /// Default tap detection level: 2G, 31.25ms duration, single tap only
-    pub fn new(i2c: I2C) -> Result<Self, Error<E>> {
-        Self::new_with_data_format(i2c, DataFormatFlags::default())
+    pub fn new(transport: T) -> Result<Self, Error<TransportError<EBUS, EPIN>>> {
+        Self::new_with_data_format(transport, DataFormatFlags::default())
     }
 
     /// Create a new ADXL343 driver configured with the given data format
-    pub fn new_with_data_format<F>(i2c: I2C, data_format: F) -> Result<Self, Error<E>>
+    pub fn new_with_data_format<F>(
+        transport: T,
+        data_format: F,
+    ) -> Result<Self, Error<TransportError<EBUS, EPIN>>>
     where
         F: Into<DataFormatFlags>,
     {
         let mut adxl343 = Adxl343 {
-            i2c,
+            transport,
             data_format: data_format.into(),
         };
 
@@ -76,7 +81,6 @@ where
 
         // Disable interrupts
         adxl343.write_register(Register::INT_ENABLE, 0)?;
-
         // 62.5 mg/LSB
         adxl343.write_register(Register::THRESH_TAP, 20)?;
 
@@ -99,20 +103,27 @@ where
     }
 
     /// Set the device data format
-    pub fn data_format<F>(&mut self, data_format: F) -> Result<(), Error<E>>
+    pub fn data_format<F>(
+        &mut self,
+        data_format: F,
+    ) -> Result<(), Error<TransportError<EBUS, EPIN>>>
     where
         F: Into<DataFormatFlags>,
     {
         let f = data_format.into();
-        let input = [Register::DATA_FORMAT.addr(), f.bits()];
-        self.i2c.write(ADDRESS, &input)?;
+        self.transport
+            .write_register(Register::DATA_FORMAT, f.bits())?;
         self.data_format = f;
         Ok(())
     }
 
     /// Write to the given register
     // TODO: make this an internal API after enough functionality is wrapped
-    pub fn write_register(&mut self, register: Register, value: u8) -> Result<(), Error<E>> {
+    pub fn write_register(
+        &mut self,
+        register: Register,
+        value: u8,
+    ) -> Result<(), Error<TransportError<EBUS, EPIN>>> {
         // Preserve the invariant around self.data_format
         assert_ne!(
             register,
@@ -120,22 +131,23 @@ where
             "set data format with Adxl343::data_format"
         );
 
-        debug_assert!(!register.read_only(), "can't write to read-only register");
-        self.i2c.write(ADDRESS, &[register.addr(), value])?;
+        self.transport.write_register(register, value)?;
         Ok(())
     }
 
-    /// Write to a given register, then read the result
+    /// Read from a given register
     // TODO: make this an internal API after enough functionality is wrapped
-    pub fn write_read_register(&mut self, register: Register, buffer: &mut [u8]) -> Result<(), E> {
-        self.i2c.write_read(ADDRESS, &[register.addr()], buffer)
+    pub fn read_register<const N: usize>(
+        &mut self,
+        register: Register,
+    ) -> Result<[u8; N], Error<TransportError<EBUS, EPIN>>> {
+        let b = self.transport.read_register(register)?;
+        Ok(b)
     }
 
     /// Get the device ID
-    fn get_device_id(&mut self) -> Result<u8, E> {
-        let input = [Register::DEVID.addr()];
-        let mut output = [0u8];
-        self.i2c.write_read(ADDRESS, &input, &mut output)?;
+    fn get_device_id(&mut self) -> Result<u8, TransportError<EBUS, EPIN>> {
+        let output: [u8; 1] = self.transport.read_register(Register::DEVID)?;
         Ok(output[0])
     }
 
@@ -147,9 +159,8 @@ where
     /// "The output data is twos complement, with DATAx0 as the least
     /// significant byte and DATAx1 as the most significant byte"
     #[cfg(feature = "i16x3")]
-    fn write_read_i16(&mut self, register: Register) -> Result<i16, E> {
-        let mut buffer = [0u8; 2];
-        self.write_read_register(register, &mut buffer)?;
+    fn write_read_i16(&mut self, register: Register) -> Result<i16, TransportError<EBUS, EPIN>> {
+        let buffer: [u8; 2] = self.transport.read_register(register)?;
         Ok(i16::from_be_bytes(buffer))
     }
 
@@ -161,23 +172,23 @@ where
     /// "A setting of 1 in the justify bit selects left-justified (MSB) mode,
     /// and a setting of 0 selects right-justified mode with sign extension."
     #[cfg(feature = "u16x3")]
-    fn write_read_u16(&mut self, register: Register) -> Result<u16, E> {
-        let mut buffer = [0u8; 2];
-        self.write_read_register(register, &mut buffer)?;
+    fn write_read_u16(&mut self, register: Register) -> Result<u16, TransportError<EBUS, EPIN>> {
+        let buffer: [u8; 2] = self.read_register(register)?;
         Ok(u16::from_le_bytes(buffer))
     }
 }
 
 #[cfg(feature = "i16x3")]
-impl<I2C, E> Accelerometer for Adxl343<I2C>
+impl<T, EBUS, EPIN> Accelerometer for Adxl343<T>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-    E: Debug,
+    T: Transport<BusError = EBUS, PinError = EPIN>,
+    EBUS: Debug,
+    EPIN: Debug,
 {
-    type Error = E;
+    type Error = TransportError<EBUS, EPIN>;
 
     /// Get normalized ±g reading from the accelerometer.
-    fn accel_norm(&mut self) -> Result<F32x3, Error<E>> {
+    fn accel_norm(&mut self) -> Result<F32x3, Error<Self::Error>> {
         let raw_data: I16x3 = self.accel_raw()?;
         let range: f32 = self.data_format.range().into();
 
@@ -201,15 +212,16 @@ where
 }
 
 #[cfg(feature = "i16x3")]
-impl<I2C, E> RawAccelerometer<I16x3> for Adxl343<I2C>
+impl<T, EBUS, EPIN> RawAccelerometer<I16x3> for Adxl343<T>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-    E: Debug,
+    T: Transport<BusError = EBUS, PinError = EPIN>,
+    EBUS: Debug,
+    EPIN: Debug,
 {
-    type Error = E;
+    type Error = TransportError<EBUS, EPIN>;
 
     /// Get acceleration reading from the accelerometer
-    fn accel_raw(&mut self) -> Result<I16x3, Error<E>> {
+    fn accel_raw(&mut self) -> Result<I16x3, Error<Self::Error>> {
         if self.data_format.contains(DataFormatFlags::JUSTIFY) {
             return Err(Error::new(ErrorKind::Mode));
         }
@@ -223,15 +235,16 @@ where
 }
 
 #[cfg(feature = "u16x3")]
-impl<I2C, E> RawAccelerometer<U16x3> for Adxl343<I2C>
+impl<T, EBUS, EPIN> RawAccelerometer<U16x3> for Adxl343<T>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-    E: Debug,
+    T: Transport<BusError = EBUS, PinError = EPIN>,
+    EBUS: Debug,
+    EPIN: Debug,
 {
-    type Error = E;
+    type Error = TransportError<EBUS, EPIN>;
 
     /// Get acceleration reading from the accelerometer
-    fn accel_raw(&mut self) -> Result<U16x3, Error<E>> {
+    fn accel_raw(&mut self) -> Result<U16x3, Error<Self::Error>> {
         if !self.data_format.contains(DataFormatFlags::JUSTIFY) {
             return Err(Error::new(ErrorKind::Mode));
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,138 @@
+use crate::register::Register;
+use crate::ADDRESS;
+use core::fmt::Debug;
+use embedded_hal::blocking::spi;
+use embedded_hal::{blocking::i2c, digital::v2::OutputPin};
+
+/// Error type for sensor transport
+pub enum TransportError<EBUS, EPIN> {
+    /// Error variant for the transport bus itself
+    BusError(EBUS),
+    /// Error variant for pins associated with transport (SPI Chip Select)
+    PinError(EPIN),
+}
+
+pub trait Transport {
+    type BusError;
+    type PinError;
+    fn write_register(
+        &mut self,
+        register: Register,
+        value: u8,
+    ) -> Result<(), TransportError<Self::BusError, Self::PinError>>;
+    fn read_register<const N: usize>(
+        &mut self,
+        register: Register,
+    ) -> Result<[u8; N], TransportError<Self::BusError, Self::PinError>>;
+}
+
+impl<EBUS, EPIN> Debug for TransportError<EBUS, EPIN>
+where
+    EBUS: Debug,
+    EPIN: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        match self {
+            Self::BusError(e) => write!(f, "{:?}", e),
+            Self::PinError(e) => write!(f, "{:?}", e),
+        }
+    }
+}
+
+/// Device transport using I2C
+pub struct I2cTransport<I> {
+    i2c: I,
+}
+
+impl<I> I2cTransport<I> {
+    /// Create a new I2C transport
+    pub fn new(i2c: I) -> Self {
+        Self { i2c }
+    }
+}
+
+impl<I, E> Transport for I2cTransport<I>
+where
+    I: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+{
+    type BusError = E;
+    type PinError = ();
+    fn write_register(
+        &mut self,
+        register: Register,
+        value: u8,
+    ) -> Result<(), TransportError<Self::BusError, Self::PinError>> {
+        debug_assert!(!register.read_only(), "can't write to read-only register");
+        self.i2c
+            .write(ADDRESS, &[register.addr(), value])
+            .map_err(|e| TransportError::BusError(e))?;
+        Ok(())
+    }
+
+    fn read_register<const N: usize>(
+        &mut self,
+        register: Register,
+    ) -> Result<[u8; N], TransportError<Self::BusError, Self::PinError>> {
+        let mut buffer: [u8; N] = [0; N];
+        self.i2c
+            .write_read(ADDRESS, &[register.addr()], &mut buffer)
+            .map_err(|e| TransportError::BusError(e))?;
+        Ok(buffer)
+    }
+}
+
+/// Device transport using SPI
+pub struct SpiTransport<SPI, CS> {
+    spi: SPI,
+    cs: CS,
+}
+
+impl<SPI, CS> SpiTransport<SPI, CS> {
+    /// Create a new SPI transport
+    pub fn new(spi: SPI, cs: CS) -> Self {
+        Self { spi, cs }
+    }
+}
+
+impl<SPI, CS, EBUS, EPIN> Transport for SpiTransport<SPI, CS>
+where
+    SPI: spi::Transfer<u8, Error = EBUS> + spi::Write<u8, Error = EBUS>,
+    CS: OutputPin<Error = EPIN>,
+{
+    type BusError = EBUS;
+    type PinError = EPIN;
+    fn write_register(
+        &mut self,
+        register: Register,
+        value: u8,
+    ) -> Result<(), TransportError<Self::BusError, Self::PinError>> {
+        debug_assert!(!register.read_only(), "can't write to read-only register");
+
+        self.cs.set_low().map_err(|e| TransportError::PinError(e))?;
+        self.spi
+            .write(&[register.addr(), value])
+            .map_err(|e| TransportError::BusError(e))?;
+        self.cs
+            .set_high()
+            .map_err(|e| TransportError::PinError(e))?;
+        Ok(())
+    }
+
+    fn read_register<const N: usize>(
+        &mut self,
+        register: Register,
+    ) -> Result<[u8; N], TransportError<Self::BusError, Self::PinError>> {
+        self.cs.set_low().map_err(|e| TransportError::PinError(e))?;
+        self.spi
+            .write(&[register.addr() | 0x80])
+            .map_err(|e| TransportError::BusError(e))?;
+        let mut buffer: [u8; N] = [0; N];
+        self.spi
+            .transfer(&mut buffer)
+            .map_err(|e| TransportError::BusError(e))?;
+        self.cs
+            .set_high()
+            .map_err(|e| TransportError::PinError(e))?;
+        Ok(buffer)
+    }
+}


### PR DESCRIPTION
* Generalize transport into a trait and implement it for i2c
* Implement SPI based transport

I've been testing this with an ADXL345, and it "works" for me, but I've not looked much at the actual data output other than confirm it changes in the expected places depending on which axis I rotate.